### PR TITLE
Listen to mousemove and mouseup on window to allow dragging outside the frame

### DIFF
--- a/main.js
+++ b/main.js
@@ -207,8 +207,8 @@ FilterToolTip.prototype = {
           };
 
           const mouseUp = e => {
-            document.body.removeEventListener("mousemove", mouseMove);
-            document.body.removeEventListener("mouseup", mouseUp);
+            removeEventListener("mousemove", mouseMove);
+            removeEventListener("mouseup", mouseUp);
             document.body.removeEventListener("keydown", keyDown);
             document.body.removeEventListener("keyup", keyUp);
             let event = new UIEvent("change");
@@ -235,8 +235,8 @@ FilterToolTip.prototype = {
 
           document.body.addEventListener("keydown", keyDown);
           document.body.addEventListener("keyup", keyUp);
-          document.body.addEventListener("mouseup", mouseUp);
-          document.body.addEventListener("mousemove", mouseMove);
+          addEventListener("mouseup", mouseUp);
+          addEventListener("mousemove", mouseMove);
         });
       }
 


### PR DESCRIPTION
With the current label dragging implementation, the values stop being updated when the mouse leaves the main window frame.
Listening to mousemove and mouseup on the window fixes that. And that's going to be very important when the editor is inside a small tootip window.
