### PR TITLE
Set the multiplier from the start

### DIFF
--- a/main.js
+++ b/main.js
@@ -197,7 +197,13 @@ FilterToolTip.prototype = {
 
         label.addEventListener("mousedown", e => {
           startX = e.clientX;
-          startValue = parseFloat(input.value, 10);
+          startValue = parseFloat(input.value);
+
+          if (e.altKey) {
+            multiplier = 0.1;
+          } else if (e.shiftKey) {
+            multiplier = 10;
+          }
 
           const mouseMove = e => {
             if (startX === null) return;
@@ -214,8 +220,8 @@ FilterToolTip.prototype = {
           const mouseUp = e => {
             removeEventListener("mousemove", mouseMove);
             removeEventListener("mouseup", mouseUp);
-            document.body.removeEventListener("keydown", keyDown);
-            document.body.removeEventListener("keyup", keyUp);
+            removeEventListener("keydown", keyDown);
+            removeEventListener("keyup", keyUp);
             let event = new UIEvent("change");
             input.dispatchEvent(event);
           };
@@ -223,23 +229,23 @@ FilterToolTip.prototype = {
           const keyDown = e => {
             if (e.altKey) {
               multiplier = 0.1;
-              startValue = parseFloat(input.value, 10);
+              startValue = parseFloat(input.value);
               startX = lastX;
             } else if (e.shiftKey) {
               multiplier = 10;
-              startValue = parseFloat(input.value, 10);
+              startValue = parseFloat(input.value);
               startX = lastX;
             }
           };
 
           const keyUp = e => {
             multiplier = 1;
-            startValue = parseFloat(input.value, 10);
+            startValue = parseFloat(input.value);
             startX = lastX;
           };
 
-          document.body.addEventListener("keydown", keyDown);
-          document.body.addEventListener("keyup", keyUp);
+          addEventListener("keydown", keyDown);
+          addEventListener("keyup", keyUp);
           addEventListener("mouseup", mouseUp);
           addEventListener("mousemove", mouseMove);
         });


### PR DESCRIPTION
Having keydown/keyup listeners is a good thing because it allows to change the multiplier while dragging, but you also need to set it correctly from the start, otherwise you can't first press the key and then start dragging.
Also, I've removed the useless second param to parseFloat.
And added the keydown/up listeners on window instead of document, it makes no difference, but it's more consistent with the other listeners I guess.
